### PR TITLE
fix(postgres): ensure that the connection pool is reused across queries

### DIFF
--- a/internal/db/postgres_test.go
+++ b/internal/db/postgres_test.go
@@ -22,6 +22,14 @@ func TestConnectToDB(t *testing.T) {
 	assert.Equal(t, reflect.TypeOf(result), reflect.TypeOf(db))
 }
 
+func TestConnectionPoolConfiguration(t *testing.T) {
+	pm := PostgresManager{}
+	os.Setenv("MPS_DB_MAX_OPEN_CONNS", "7")
+	_, err := pm.Connect()
+	assert.Nil(t, err, "test failed to connect db")
+	assert.Equal(t, 7, pm.connection.Stats().MaxOpenConnections, "connection pool max open conns not configured")
+}
+
 func TestGetMPSInstancewithGUID(t *testing.T) {
 	pm := PostgresManager{}
 


### PR DESCRIPTION
## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [X] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable (n.a.)
- [X] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency. (n.a.)


## What are you changing?
Our testing environment for OACT uses small postgres instances with a connection limit of 25. While testing the features in sample-web-ui, we noticed that mps-router started failing to connect to the database while logging a lot of `remaining connection slots are reserved for non-replication superuser connections` errors. This resulted in the service being unreliable and features like power state discovery became unreliable.

The error message indicates that mps-router exhausts the connection limit of the postgres instance. Without this PR, mps-router will create a new connection pool in every `Connect()` call which is also disposed again due to `Close()` calls right after a single query. Since power state discovery in sample-web-ui triggers quite a lot of requests depending on page size, this quickly opens too many connections to the database.

This PR changes `postgres.go` so that it only creates a connection pool once which will then reuse the connections it opens for later queries. It also introduces a new optional environment variable `MPS_DB_MAX_OPEN_CONNS` which can be used to set the maximum number of connections in the connection pool. By default (and if the variable is unset), the pool does not use any limits. This configuration option enables the administrator to tune the pool to the available database resources.

These changes eliminated the error messages in our testing environment and made power state discovery much more reliable.