### PR TITLE
ci(deps): group codeql-action sub-action updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
     directory: /
     schedule:
       interval: daily
+    # codeql-action's sub-actions release in lockstep; one PR instead of four.
+    groups:
+      codeql-action:
+        patterns:
+          - 'github/codeql-action*'
 
   - package-ecosystem: docker
     directory: /


### PR DESCRIPTION
github/codeql-action/{init,analyze,autobuild,upload-sarif} are released in lockstep from one repo but land as separate dependabot PRs. Group them so each bump opens a single PR.

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.


## What are you changing?
<!-- Please provide a short description of the updates that are in the PR -->


## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
